### PR TITLE
Add GitHub Actions workflow for daily blog draft PRs

### DIFF
--- a/daily-draft-pr.yml
+++ b/daily-draft-pr.yml
@@ -1,0 +1,81 @@
+# https://chatgpt.com/c/695a3c15-0964-8320-a3af-991876c35462
+name: Daily Jekyll draft PR (one PR per day)
+
+on:
+  schedule:
+    # GitHub Actions の cron は UTC
+    # 19:30 JST = 10:30 UTC
+    - cron: "30 10 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-draft-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Compute date variables (JST)
+        id: vars
+        shell: bash
+        run: |
+          set -euo pipefail
+          TODAY="$(TZ=Asia/Tokyo date +%F)"   # YYYY-MM-DD
+          echo "today=${TODAY}" >> "$GITHUB_OUTPUT"
+          echo "slug=${TODAY}_daily" >> "$GITHUB_OUTPUT"
+          echo "branch=auto/daily-draft-${TODAY}" >> "$GITHUB_OUTPUT"
+
+      - name: Create today's draft file
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          FILE="_drafts/${{ steps.vars.outputs.slug }}.md"
+          mkdir -p _drafts
+
+          # すでに存在する場合は何もしない（= その日のPRは作らない）
+          if [ -f "$FILE" ]; then
+            echo "Draft already exists: $FILE"
+            exit 0
+          fi
+
+          printf '%s\n' '---' \
+            'layout: post' \
+            'title: "${{ steps.vars.outputs.slug }}"' \
+            'date: ${{ steps.vars.outputs.today }} 19:30:00 +0900' \
+            '---' > "$FILE"
+
+          echo "Created: $FILE"
+
+      - name: Create Pull Request (one per day)
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+          # PRの向き先
+          base: gh-pages
+
+          # ★ 日付入りブランチ → 毎日別PR
+          branch: ${{ steps.vars.outputs.branch }}
+          delete-branch: false
+
+          add-paths: |
+            _drafts/*.md
+
+          commit-message: "Add daily draft: ${{ steps.vars.outputs.slug }}"
+          title: "Daily draft: ${{ steps.vars.outputs.slug }}"
+          body: |
+            Auto-generated daily Jekyll draft.
+
+            - File: _drafts/${{ steps.vars.outputs.slug }}.md
+            - Created at: JST 19:30
+          labels: |
+            daily
+            draft


### PR DESCRIPTION
## 概要
毎日JST 19:30に自動でブログのドラフト記事を生成し、PRを作成するGitHub Actions ワークフローを追加しました。

## 変更内容
- `daily-draft-pr.yml`: 毎日のドラフト記事作成ワークフロー
  - スケジュール: 毎日JST 19:30 (UTC 10:30)
  - 日付ごとに別ブランチを作成し、1日1PRの運用を実現
  - 既存のドラフトがある場合はスキップ
  - printfを使用してクリーンなMarkdownファイルを生成

## テストプラン
- [ ] `workflow_dispatch`で手動実行してワークフローが正常に動作することを確認
- [ ] 生成されたドラフトファイルのフォーマットを確認
- [ ] 既存ファイルがある場合のスキップ動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)